### PR TITLE
Fix bench_utils.hh compilation on macOS

### DIFF
--- a/test/bench_utils.hh
+++ b/test/bench_utils.hh
@@ -19,7 +19,8 @@
 #include <signal.h>
 #if defined(__APPLE__)
 #include <malloc/malloc.h>
-#elif defined(__linux__) || defined(__GLIBC__)
+#include <sys/sysctl.h>
+#elif defined(__GLIBC__)
 #include <malloc.h>
 #endif
 
@@ -36,6 +37,18 @@ inline void print_sysinfo() {
         std::cout << "OS:        " << uts.sysname << " " << uts.release
                   << " " << uts.machine << std::endl;
 
+#if defined(__APPLE__)
+    char cpu_buf[256];
+    size_t cpu_buf_len = sizeof(cpu_buf);
+    if (sysctlbyname("machdep.cpu.brand_string", cpu_buf, &cpu_buf_len, nullptr, 0) == 0) {
+        std::cout << "CPU:       " << cpu_buf << std::endl;
+    }
+    uint64_t ram_bytes = 0;
+    size_t ram_len = sizeof(ram_bytes);
+    if (sysctlbyname("hw.memsize", &ram_bytes, &ram_len, nullptr, 0) == 0) {
+        std::cout << "RAM:       " << (ram_bytes / (1024 * 1024)) << " MB" << std::endl;
+    }
+#else
     std::ifstream cpuinfo("/proc/cpuinfo");
     if (cpuinfo) {
         std::string line;
@@ -57,6 +70,7 @@ inline void print_sysinfo() {
                 break;
             }
     }
+#endif
 
 #ifdef __VERSION__
     std::cout << "Compiler:  g++ " << __VERSION__ << std::endl;
@@ -75,7 +89,7 @@ inline long get_heap_bytes() {
 #if defined(__APPLE__)
     struct mstats ms = mstats();
     return static_cast<long>(ms.bytes_used);
-#elif defined(__linux__) || defined(__GLIBC__)
+#elif defined(__GLIBC__)
     struct mallinfo2 mi = mallinfo2();
     return static_cast<long>(mi.uordblks) + static_cast<long>(mi.hblkhd);
 #else

--- a/test/bench_utils.hh
+++ b/test/bench_utils.hh
@@ -17,7 +17,11 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <signal.h>
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#elif defined(__linux__) || defined(__GLIBC__)
 #include <malloc.h>
+#endif
 
 struct BenchResult { std::string name; double ms; };
 static std::vector<BenchResult> _bench_results;
@@ -68,8 +72,15 @@ inline void print_sysinfo() {
 // ---- Heap measurement ----
 
 inline long get_heap_bytes() {
+#if defined(__APPLE__)
+    struct mstats ms = mstats();
+    return static_cast<long>(ms.bytes_used);
+#elif defined(__linux__) || defined(__GLIBC__)
     struct mallinfo2 mi = mallinfo2();
     return static_cast<long>(mi.uordblks) + static_cast<long>(mi.hblkhd);
+#else
+#error "Unsupported platform for heap measurement"
+#endif
 }
 
 // ---- Fork-based execution core ----


### PR DESCRIPTION
# 问题

`test/bench_utils.hh` 在 macOS 上无法编译，因为它无条件地包含了 `<malloc.h>` 并使用了 glibc 专属的 `mallinfo2()`，而这两个接口在 Apple 平台上都不存在。

**macOS 上的编译错误：**
```
test/bench_utils.hh:20:10: fatal error: 'malloc.h' file not found
#include <malloc.h>
         ^~~~~~~~~~
```

## 解决方案

为堆内存测量代码添加平台条件编译：

- **Linux/glibc**：保留现有的 `<malloc.h>` + `mallinfo2()` 路径。
- **macOS**：包含 `<malloc/malloc.h>`，使用 `mstats().bytes_used`。
- **其他平台**：产生编译时错误，避免静默隐藏问题。

## 为什么 `mstats().bytes_used` 是正确的

在 Linux/glibc 下，原代码计算：

```cpp
mallinfo2().uordblks + mallinfo2().hblkhd
```

根据 [Linux man-pages `mallinfo2(3)`](https://man7.org/linux/man-pages/man3/mallinfo.3.html)：

- `uordblks` — "The total number of bytes used by in-use allocations."
- `hblkhd`  — "The number of bytes in blocks currently allocated using mmap(2)."

两者相加表示**当前堆上已分配且仍在使用中的总字节数**。

在 macOS 上，SDK 头文件 `<malloc/malloc.h>` 中声明了 `mstats()` 接口：

```c
struct mstats {
    size_t  bytes_total;
    size_t  chunks_used;
    size_t  bytes_used;
    size_t  chunks_free;
    size_t  bytes_free;
};
extern struct mstats mstats(void);
```

从字段命名即可看出，`bytes_used` 表示**当前已使用的字节数**。

同一份头文件中，`malloc_zone_statistics()` 的注释也说明：

```c
extern void malloc_zone_statistics(malloc_zone_t *zone, malloc_statistics_t *stats);
    /* Fills statistics for zone; if !zone, sums up all zones */
```

macOS 10.13.3 的 libmalloc 开源实现（[`libmalloc/src/malloc.c`](https://github.com/zzcentury/macOS-10.13.3-Source/blob/master/libmalloc-140.40.1/src/malloc.c)）进一步将上述两点联系起来：

```c
struct mstats mstats(void)
{
    malloc_statistics_t s;
    struct mstats m;

    malloc_zone_statistics(NULL, &s);
    m.bytes_total = s.size_allocated;
    m.chunks_used = s.blocks_in_use;
    m.bytes_used  = s.size_in_use;
    m.chunks_free = 0;
    m.bytes_free  = m.bytes_total - m.bytes_used;

    return (m);
}
```

这段代码显示：

1. `mstats()` 内部调用 `malloc_zone_statistics(NULL, &s)`。根据头文件注释，传 `NULL` 时会汇总所有 zone 的统计信息。
2. `mstats().bytes_used` 对应的就是 `s.size_in_use`。
3. 因此，`mstats().bytes_used` 与 glibc 的 `mallinfo2().uordblks + mallinfo2().hblkhd` 在"测量当前已分配堆内存"这一用途上语义等价。

## 验证

- **macOS**：修改后 `make bench-clpoly` 能够正常编译并运行。
- **Linux**：glibc 路径完全未改动，功能无变化。