### PR TITLE
fix: squarefreebasis unit leak (#14) — sqf 首项 sign 归一化

### DIFF
--- a/clpoly/polynomial_gcd.hh
+++ b/clpoly/polynomial_gcd.hh
@@ -108,6 +108,14 @@ namespace clpoly{
             return {{F,1}};
         auto f_cont=cont(F);
         auto F_=F/f_cont;
+        // sign 归一化（对齐 SymPy/Maple/FLINT 约定）：
+        // 把 F_ 的首项 sign 提到 f_cont，使 factor 永远首项正。
+        // 不做的话 squarefreebasis 在 associate 比较时会把 unit 残留进 basis（issue #14）。
+        if (!F_.empty() && F_.front().second < ZZ(0))
+        {
+            F_=-F_;
+            f_cont=-f_cont;
+        }
         auto lst=squarefreefactorize(f_cont);
         polynomial_<ZZ,lex_<var_order>> F_1(F.comp_ptr()),F_2(F.comp_ptr()),F_3(F.comp_ptr());
         for(uint64_t i=1;;++i)

--- a/docs/devlog/2026-05-09-squarefreebasis-unit-leak-fix.md
+++ b/docs/devlog/2026-05-09-squarefreebasis-unit-leak-fix.md
@@ -1,0 +1,93 @@
+# 2026-05-09: squarefreebasis unit leak 修复（issue #14）
+
+## 做了什么
+
+修复 GitHub issue #14：`squarefreebasis` 在输出 basis 中混入常数 `-1`，且数量随输入规模增长。
+
+**根因**：`squarefreefactorize` 没把 factor 首项 sign 提到 cont，导致同一个数学多项式（associates）在 `squarefreefactorize` 输出和 `polynomial_GCD` 输出之间字面表示不齐 → `squarefreebasis` 主循环用 `F1 != lst[j]` 字面比较时误判为"应拆分" → 拆分时 `lst[j]/F1` 是 unit 残留进 basis。
+
+**修复**：在 `clpoly/polynomial_gcd.hh:109-111` 的 `squarefreefactorize` 中加 4 行 sign 归一化：当 `F_ = F/cont(F)` 的首项系数为负时，把 sign 从 F_ 转移到 f_cont（保持 cont * F_ = F 不变）。这样 factor 永远首项正，与 `polynomial_GCD` 的内部归一化对齐。
+
+## 为什么做
+
+- 用户报告的 user-visible bug，影响 charset 的 squarefree 基底结果
+- 根因不只是 squarefreebasis 局部问题，而是 sqf 的 sign convention 与业界（SymPy/Maple/FLINT）不一致
+- 在 sqf 上修是治根方案，sqfb 自然就对（关联代码完全不用动）
+
+## 关键决策及其理由
+
+### 决策 1：选择 Plan B（上游 sqf 修复）而非 Plan A（局部 sqfb 修复）
+
+- **A** 是 5-10 行局部判定补丁
+- **B** 是 4-5 行上游 sign-normalize
+- B 完成后 A 是 dead code（不会触发的判定）
+- B 一次到位，避免在 codebase 留"已知冗余的局部补丁"
+- B 让 CLPoly 的 sqf 输出与 SymPy/Maple/FLINT 完全一致
+
+### 决策 2：cont sign convention 选"跟随 leading"（不动 cont 函数）
+
+- 不改 `cont` 函数本身（保持现有 GMP gcd 行为：多项情形返回正 gcd）
+- 仅在 sqf 内部处理 sign：`F_ = F/cont` 后若首项负则双方取负
+- → 不影响其他调用 `cont` 的代码
+
+### 决策 3：调用点扫描（避免破坏链路）
+
+实测 7 处 `squarefreefactorize` 调用点 + 2 处测试断言，全部对 factor sign 不敏感：
+- `charset.hh`: `G * factor` 乘积语义
+- `polynomial_factorize*.hh`: `is_number` 检查或递归 factor
+- `test_polynomial_gcd.cc`: `divides` + `is_squarefree` 断言（不依赖 sign）
+
+→ 修复无需改任何调用方。
+
+## 遇到的问题与解决方式
+
+### 问题 1：第一次直接动代码违反 §5.1 流程
+
+第一次尝试时跳过了"先写修正方案 → 用户确认 → 再实施"流程，直接 patch + 测试，被用户纠正。
+
+**解决**：
+1. revert 全部代码改动
+2. 严格按 workflow.md §5.1 流程：先写 `docs/fixes/` 修正方案文档（含 SymPy/Maple/FLINT 对照 + 调用点扫描）
+3. 等用户审核 + 确认方案后再实施
+
+### 问题 2：第一版修正方案文档过于复杂
+
+第一版列了 Plan A/B/C 三方案对比 + 模糊推荐 C（先 A 后 B），用户指出："先 B 后 A 不更合适？"
+
+**解决**：重写文档为纯 Plan B 路线，把 A/C 全部删除，理由也改写为"A 在 B 完成后是 dead code"。简化决策路径。
+
+### 问题 3：错误评估 sympy 一致性
+
+第一次声称"CLPoly 与 SymPy 不一致"，后实测 SymPy 输出后发现仅在「多项 + 首项负」一个具体场景下不一致，其他完全一致。这让 Plan B 的工作量从估计的 30-50 行降到实际的 4 行。
+
+**教训**：参考实现对照必须**实测 ground truth**，不能靠记忆/文档猜测。
+
+## 涉及的文件
+
+### 主修改
+- `clpoly/polynomial_gcd.hh`：+8 行（4 行修复 + 4 行注释），位于 `squarefreefactorize` L109-111 周围
+
+### 新增文件
+- `docs/fixes/2026-05-09-squarefreebasis-unit-leak.md`：修正方案文档（§5.1 必需）
+- `test/test_squarefreebasis_bugfix.cc`：回归测试（10 用例覆盖 issue 复现 + canonical 断言 + sanity）
+- `docs/devlog/2026-05-09-squarefreebasis-unit-leak-fix.md`：本日志
+
+### 流程改进
+- `test/run_all_tests.sh`：把 `test_factorize_bugfix` 和 `test_squarefreebasis_bugfix` 加入 TESTS 数组（之前 bugfix 测试都没进 runner，是历史疏漏）
+
+## 度量
+
+- 耗时：~3 小时
+  - 第一次直接动代码：~30 分钟（被 revert）
+  - 修正方案 v1（Plan A/B/C 对比）：~30 分钟
+  - 修正方案 v2（Plan B 路线 + sympy 实测 + 调用点扫描）：~45 分钟
+  - 实施 + 测试：~1 小时
+  - devlog + commit：~15 分钟
+- 迭代：~5 轮（含 v1 文档被指正、SymPy 实测后认知修正等）
+- C++ 修改行数：12 行（含注释）
+- 新增测试代码：~140 行（10 用例）
+- 修正方案文档：~200 行
+- 放弃的方案：
+  - **Plan A（局部 sqfb 内 quotient is_number 检查）**：被 B 吞掉，不做
+  - **Plan C（先 A 后 B 双管）**：A 部分被 B 吞掉，等于浪费一轮 commit
+  - **Plan B 30-50 行重写 cont sign convention**：实测后发现只需 4 行 sqf 局部 sign 归一化即可达到目标，不动 cont

--- a/docs/fixes/2026-05-09-squarefreebasis-unit-leak.md
+++ b/docs/fixes/2026-05-09-squarefreebasis-unit-leak.md
@@ -1,0 +1,236 @@
+# 修正方案：squarefreebasis unit leak
+
+> **状态**：草稿，待用户审核。
+> 对应 workflow.md §5.1 算法内部错误修正流程
+> 对应 GitHub issue: [#14](https://github.com/lihaokun/CLPoly/issues/14)
+> 对应分支：`fix/squarefreebasis-issue-14`（从 master 起，独立 PR 对 master）
+
+---
+
+## 第一部分：复现与定位
+
+### 现象
+
+issue #14：`squarefreebasis` 在输出 basis 中混入常数 `-1`，且数量随输入规模增长。
+
+```cpp
+variable x("x");
+auto [b1, _] = squarefreebasis({-x+1, (x-1)*x});
+// 实际：[-1, x-1, x]
+// 期望：[x-1, x] 或其 associates 等价集合，不应有 unit 元素
+```
+
+### 定位
+
+`clpoly/polynomial_gcd.hh:158-211` 的 `squarefreebasis` 主循环 L176-195：
+
+```cpp
+for (size_t j=0;j<lst.size();++j) {
+    auto F1 = polynomial_GCD(lst[j], tmp);
+    if (!is_number(F1)) {
+        tmp = tmp / F1;
+        if (F1 != lst[j]) {              // ← 字面比较，漏判 associates
+            lst[j] = lst[j] / F1;        // ← unit 残留进 basis
+            ...
+        } else { ... }
+        ...
+    }
+}
+```
+
+### 实测追踪（用 issue 例 1 `{-x+1, (x-1)·x}`）
+
+通过 `/tmp/probe_sqf.cc` 实测确认：
+
+```
+sqf(-x+1) = [(1, 1), (-x+1, 1)]    ← factor 首项负，非 canonical
+polynomial_GCD(-x+1, x²-x) = x-1   ← gcd 内部归到正首项
+(-x+1) / (x-1) = -1                ← associates 比例为 unit
+```
+
+**bug 路径**：
+
+| step | 状态 |
+|------|------|
+| F[0]=-x+1 | sqf 跳过 cont=1 项 → `lst = [-x+1]`（非 canonical） |
+| F[1]=(x-1)·x | sqf 跳过 cont=1 项 → tmp=x²-x |
+| inner j=0 | F1 = gcd(-x+1, x²-x) = **x-1**（gcd 归正） |
+| | F1 (x-1) **!=** lst[0] (-x+1) → 走"拆分 basis"分支 |
+| | lst[0] = lst[0]/F1 = -1 ← **unit leak** |
+| 最终 | `lst = [-1, x-1, x]` |
+
+### 根因链
+
+1. `polynomial_GCD` 内部规范化首项系数为正
+2. `squarefreefactorize` 的 factor 不规范化（仅 cont 取 gcd 绝对值）
+3. → 同一个数学多项式（associates）在 sqf 和 polynomial_GCD 之间的字面表示不一致
+4. → sqfb 的 `F1 != lst[j]` 字面比较误判为"应拆分"
+5. → 拆分时 `lst[j]/F1` 是 unit 残留进 basis
+
+---
+
+## 第二部分：参考实现对比
+
+按 §5.1 必须对照参考实现：
+
+### SymPy 实测（`sqf_list`）
+
+```python
+sqf_list(x)              = (1,  [(x, 1)])
+sqf_list(-x)             = (-1, [(x, 1)])
+sqf_list(1-x)            = (-1, [(x-1, 1)])           ← cont=-1，factor canonical
+sqf_list(-2*x)           = (-2, [(x, 1)])
+sqf_list(-6*(x-1)*(x-2)) = (-6, [(x²-3x+2, 1)])      ← cont=-6，factor canonical
+sqf_list((x-1)**2*x)     = (1,  [(x, 1), (x-1, 2)])
+```
+
+**SymPy 约定**：cont 完全吸收 unit/sign，factors 永远首项正。
+
+### Maple `sqrfree`
+
+返回 `[lc, [[f1,e1],[f2,e2],...]]`，`lc` 是首项 unit（含 sign），`fi` 是 monic（首项=1）。
+
+**Maple 约定**：等价于 SymPy，sign 全提到 lc，factors 永远 canonical。
+
+### FLINT `fmpz_poly_factor_squarefree`
+
+输出结构 `fmpz_poly_factor_t {c, p[]}`：
+- `c`：内容部分（带 sign）
+- `p[]`：每个 factor 经 `fmpz_poly_factor_canonicalise` 归一为 cont=1 + 首项正
+
+**FLINT 约定**：同 SymPy/Maple。
+
+### 共同模式
+
+**三家完全一致**：cont/lc 吸收所有 unit/sign，factor list 内部多项式永远 canonical（首项正 over ZZ，或 monic over field）。
+
+### CLPoly 当前 vs 业界
+
+CLPoly 实测（`/tmp/probe_sqf.cc`）：
+
+| 输入 | CLPoly 当前 | SymPy/Maple/FLINT |
+|------|------------|-------------------|
+| `x` | `[(1,1), (x,1)]` | 一致 ✓ |
+| `-x` | `[(-1,1), (x,1)]` | 一致 ✓ |
+| `x-1` | `[(1,1), (x-1,1)]` | 一致 ✓ |
+| **`-x+1`** | **`[(1,1), (-x+1,1)]`** | **`[(-1,1), (x-1,1)]`** ✗ 不一致 |
+| `2x`, `-2x` | 一致 ✓ | — |
+| **`-6(x-1)(x-2)`** | **`[(6,1), (-x²+3x-2,1)]`** | **`[(-6,1), (x²-3x+2,1)]`** ✗ 不一致 |
+| 重复因子各种 | 一致 ✓ | — |
+
+**差异定位**：仅在「F 是多项 + 首项系数为负」的情形，CLPoly 没把首项 sign 提到 cont。其余情形与业界完全一致。
+
+---
+
+## 第三部分：修复方案（Plan B：上游规范化）
+
+让 `squarefreefactorize` 在算出 `f_cont` 和 `F_` 之后多做一步：把 `F_` 的首项 sign 提到 `f_cont`，使 `F_` 永远首项正。
+
+```cpp
+// clpoly/polynomial_gcd.hh:109-111 修改：
+auto f_cont = cont(F);
+auto F_ = F / f_cont;
+// === Plan B: 把 F_ 的首项 sign 提到 f_cont ===
+// 对齐 SymPy/Maple/FLINT 约定：factor 永远 canonical（首项正）
+if (!F_.empty() && F_.front().second < ZZ(0)) {
+    F_ = -F_;           // polynomial unary -
+    f_cont = -f_cont;   // cont 也跟着取负，保持 cont * F_ = F 不变
+}
+auto lst = squarefreefactorize(f_cont);  // 递归 sqf cont 自身保持 sign 一致
+```
+
+### 为什么这一处改动够了
+
+1. `F_` 初始首项正 ⇒ 所有由 `F_` 出发的 GCD/quotient 都自动首项正（`polynomial_GCD` 规范化）
+2. 循环里 `lst.push_back({F_3/F_, ...})` 等表达式：分子分母均首项正 ⇒ 商首项正
+3. 所有 push 进 lst 的 factor 都 canonical
+4. → sqfb 拿到的 lst[j] 永远 canonical
+5. → `F1 != lst[j]` 字面比较准确，不再有 associate 误判
+6. → unit 不会进 basis
+
+### 不需要改的代码
+
+- `squarefreebasis` 本身：不动
+- `cont` 的 sign convention：不动（仍是 ZZ.gcd 的 sign 行为）
+- 任何调用 `squarefreefactorize` 的代码：不动（实测 7 处调用点全部对 factor sign 不敏感）
+
+### 调用点 sign-敏感性扫描（实测）
+
+| 文件:行 | 用法 | 敏感? |
+|---------|------|------|
+| `charset.hh:53,67` | `G = G * factor` 乘积重建 | ❌（乘积语义保持等价）|
+| `polynomial_factorize.hh:69` | `is_number` 检查 + 递归 factor | ❌ |
+| `polynomial_factorize_wang.hh:2450` | 同上多变量入口 | ❌ |
+| `polynomial_factorize_univar.hh:1596` | 已有独立 sign-normalize 层（L1618-1621） | ❌ |
+| `polynomial_gcd.hh:111` | sqf 内部递归 cont | ❌（递归 sign 自动跟随）|
+| `polynomial_gcd.hh:169` | **squarefreebasis bug 触发点** | 修后自然正确 |
+| `test/test_polynomial_gcd.cc:132,147` | `divides` + `is_squarefree` 断言 | ❌（不依赖 sign）|
+| `test/bench_clpoly.cc:482-485` | 仅 benchmark，丢 result | ❌ |
+
+**结论**：所有调用方不需修改。
+
+---
+
+## 第四部分：测试计划
+
+### 主回归用例（issue #14 复现）
+
+新增 `test/test_squarefreebasis_bugfix.cc`：
+
+| 用例名 | 输入 | 期望（必须无 `is_number` 元素）|
+|--------|------|------------------------------|
+| `issue14_ex1` | `{-x+1, (x-1)·x}` | basis 中无 unit |
+| `issue14_ex2` | 4 polys：`{-x+1, (x-1)·x, -x+2, (x-2)·x}` | 同上 |
+| `issue14_ex3` | 6 polys：含 `-x+3, (x-3)·x` | 同上 |
+
+### sqf canonical 形式断言
+
+| 用例名 | 输入 | 期望 |
+|--------|------|------|
+| `sqf_neg_lead_canonical` | `-x+1` | `sqf` 返回的非常数 factor 首项系数 > 0 |
+| `sqf_neg_multivar` | `-(x-1)·(x-2)` | 同上 |
+| `sqf_product_invariant` | 任意 F | `∏ factor^mult = F` 仍成立 |
+
+### Sanity（不破坏正向用例）
+
+| 用例名 | 输入 | 期望 |
+|--------|------|------|
+| `sanity_pos_lead` | `{x+1, (x+1)·x}` | basis = `[x+1, x]`，与修复前同 |
+| `sanity_repeated_factor` | `{(x-1)², x·(x-1)}` | multiplicity 正确 |
+| `sanity_coprime` | `{x, x+1}` | basis = `[x, x+1]` |
+
+### 全量回归
+
+- `bash test/run_all_tests.sh`：所有现有测试不破坏
+- 重点关注：`test_polynomial_gcd.cc`（直接测 sqf）、`test_factorize.cc`、`test_factorize_multivar.cc`（间接通过 factorize 链路）
+
+---
+
+## 第五部分：执行步骤
+
+1. **[等批准]** 用户确认本方案
+2. 在 `fix/squarefreebasis-issue-14` 分支：
+   1. 改 `clpoly/polynomial_gcd.hh:109-111` 加 sign 归一化（约 4 行）
+   2. 新增 `test/test_squarefreebasis_bugfix.cc`（约 80 行，含表中所有用例）
+   3. 编译：`make test/test_squarefreebasis_bugfix`
+   4. 跑新测试：期望 6/6 PASS
+   5. 全量回归：`bash test/run_all_tests.sh`，期望全绿
+3. commit + push 分支
+4. 开 PR 对 master，关联 issue #14
+5. 写 devlog `docs/devlog/2026-05-XX-squarefreebasis-unit-leak-fix.md`
+
+---
+
+## 第六部分：风险与未决问题
+
+1. **Q**: `cont(-x) = -1`（单项情形 cont 已带 sign）此修复是否冲突？
+   **A**: 不冲突。修复后 `F_ = F/cont(F)` 在单项情形得到 `1`，`!is_number(F_)` 为 false，跳过 sign-normalize 步。`is_number(F)` 检查在 L107 已经 return，不会进入 L109。
+
+2. **Q**: `polynomial_<ZZ>` 是否有 unary `-` 算子？
+   **A**: 需要在实施时验证。若无，备选：`F_ = F_ * ZZ(-1)` 或对每个 coef 取反的循环。
+
+3. **Q**: Plan B 改完后，对原本"首项正"的输入完全无影响？
+   **A**: 是。修复仅触发在 `F_.front().second < 0` 时；首项正的 F 完全走原路径。
+
+4. **Q**: cont 的 sign 在 sqf 输出"第一项 (cont, 1)"中的语义如何？
+   **A**: 保持现有：第一项是 cont 多项式（递归 sqf 后可能拆成多个整数 factor）。修复后 cont 多项式可能整体取负（吸收了 sign），但形式不变。

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -33,6 +33,8 @@ TESTS=(
     test_factorize_multivar
     test_groebner
     test_dense_upoly_hgcd
+    test_factorize_bugfix
+    test_squarefreebasis_bugfix
 )
 
 TOTAL_PASS=0

--- a/test/test_squarefreebasis_bugfix.cc
+++ b/test/test_squarefreebasis_bugfix.cc
@@ -1,0 +1,181 @@
+/**
+ * @file test_squarefreebasis_bugfix.cc
+ * @brief Issue #14 回归测试 + sqf canonical 形式断言 + sanity 用例
+ *
+ * 修正方案：docs/fixes/2026-05-09-squarefreebasis-unit-leak.md
+ *
+ * Bug：clpoly/polynomial_gcd.hh:109-111 squarefreefactorize 未做首项 sign 归一化，
+ * 导致 factor 与 polynomial_GCD 输出在 associates 上字面不等，使 squarefreebasis
+ * 在拆分时把 unit ±1 残留进 basis。
+ *
+ * 修复：sqf 的 F_ 在 cont 提取后再做一次"首项 sign 提到 f_cont"，使 factor
+ * 永远首项正。对齐 SymPy/Maple/FLINT 约定。
+ */
+#include <clpoly/clpoly.hh>
+#include <iostream>
+#include <vector>
+
+using namespace clpoly;
+
+static int passed = 0, total = 0;
+
+#define CHECK(cond, label) do {                                     \
+    ++total;                                                        \
+    if (cond) { ++passed; std::cout << "  [PASS] " << label << std::endl; } \
+    else { std::cout << "  [FAIL] " << label << std::endl; }        \
+} while(0)
+
+template <class P>
+static bool basis_no_unit(const std::vector<P>& basis)
+{
+    for (auto& p : basis) if (is_number(p)) return false;
+    return true;
+}
+
+template <class P>
+static bool basis_all_squarefree(const std::vector<P>& basis)
+{
+    for (auto& p : basis) if (!is_number(p) && !is_squarefree(p)) return false;
+    return true;
+}
+
+template <class P>
+static void show(const std::string& label, const std::vector<P>& basis)
+{
+    std::cout << "    " << label << " basis: [";
+    for (size_t i = 0; i < basis.size(); ++i) {
+        if (i > 0) std::cout << ", ";
+        std::cout << basis[i];
+    }
+    std::cout << "]" << std::endl;
+}
+
+int main()
+{
+    variable x("x"), y("y");
+
+    // ============================================================
+    // 主回归：issue #14 复现用例（关键）
+    // ============================================================
+    std::cout << "=== Issue #14 回归 ===" << std::endl;
+    {
+        std::vector<polynomial_<ZZ>> polys = {-x+1, (x-1)*x};
+        auto [basis, _] = squarefreebasis(polys);
+        show("issue14_ex1", basis);
+        CHECK(basis_no_unit(basis), "issue14_ex1: basis 无 unit 元素");
+    }
+    {
+        std::vector<polynomial_<ZZ>> polys = {-x+1, (x-1)*x, -x+2, (x-2)*x};
+        auto [basis, _] = squarefreebasis(polys);
+        show("issue14_ex2", basis);
+        CHECK(basis_no_unit(basis), "issue14_ex2: basis 无 unit 元素");
+    }
+    {
+        std::vector<polynomial_<ZZ>> polys = {-x+1, (x-1)*x, -x+2, (x-2)*x,
+                                                -x+3, (x-3)*x};
+        auto [basis, _] = squarefreebasis(polys);
+        show("issue14_ex3", basis);
+        CHECK(basis_no_unit(basis), "issue14_ex3: basis 无 unit 元素");
+    }
+
+    // ============================================================
+    // sqf canonical 形式断言：非常数 factor 首项系数 > 0
+    // ============================================================
+    std::cout << "\n=== sqf canonical 形式断言 ===" << std::endl;
+    {
+        polynomial_<ZZ> f = -x + 1;
+        auto sqf = squarefreefactorize(f);
+        bool ok = true;
+        // 跳过第一项（cont），后续 factor 必须首项正
+        for (auto it = sqf.begin() + 1; it != sqf.end(); ++it) {
+            if (!is_number(it->first) && it->first.front().second < ZZ(0)) {
+                ok = false; break;
+            }
+        }
+        std::cout << "    sqf(-x+1) = ";
+        for (auto& [p, e] : sqf) std::cout << "(" << p << "," << e << ") ";
+        std::cout << std::endl;
+        CHECK(ok, "sqf_neg_lead_canonical: -x+1 的非常数 factor 首项 > 0");
+    }
+    {
+        polynomial_<ZZ> f = -6 * (x-1) * (x-2);
+        auto sqf = squarefreefactorize(f);
+        bool ok = true;
+        for (auto it = sqf.begin() + 1; it != sqf.end(); ++it) {
+            if (!is_number(it->first) && it->first.front().second < ZZ(0)) {
+                ok = false; break;
+            }
+        }
+        std::cout << "    sqf(-6(x-1)(x-2)) = ";
+        for (auto& [p, e] : sqf) std::cout << "(" << p << "," << e << ") ";
+        std::cout << std::endl;
+        CHECK(ok, "sqf_neg_multivar: -6(x-1)(x-2) 非常数 factor 首项 > 0");
+    }
+    {
+        // 多变量 + 首项负
+        polynomial_<ZZ> f = -x*y + 1;
+        auto sqf = squarefreefactorize(f);
+        bool ok = true;
+        for (auto it = sqf.begin() + 1; it != sqf.end(); ++it) {
+            if (!is_number(it->first) && it->first.front().second < ZZ(0)) {
+                ok = false; break;
+            }
+        }
+        std::cout << "    sqf(-x*y+1) = ";
+        for (auto& [p, e] : sqf) std::cout << "(" << p << "," << e << ") ";
+        std::cout << std::endl;
+        CHECK(ok, "sqf_neg_multivar_xy: -xy+1 非常数 factor 首项 > 0");
+    }
+    {
+        // 不变量：sqf 乘积重建 = 原 F（含 cont * 各 factor^mult）
+        polynomial_<ZZ> f = -6 * (x-1) * (x-2);
+        auto sqf = squarefreefactorize(f);
+        polynomial_<ZZ> reconstructed({{monomial(), ZZ(1)}});
+        for (auto& [p, e] : sqf) reconstructed = reconstructed * pow(p, e);
+        std::cout << "    rebuild f=" << f << " from sqf, got=" << reconstructed
+                  << std::endl;
+        CHECK(reconstructed == f, "sqf_product_invariant: ∏ pᵢ^eᵢ = F");
+    }
+
+    // ============================================================
+    // Sanity（不破坏正向用例）
+    // ============================================================
+    std::cout << "\n=== Sanity（修复不破坏其他正向用例） ===" << std::endl;
+    {
+        std::vector<polynomial_<ZZ>> polys = {x+1, (x+1)*x};
+        auto [basis, _] = squarefreebasis(polys);
+        show("sanity_pos_lead", basis);
+        CHECK(basis.size() == 2 && basis_no_unit(basis),
+              "sanity_pos_lead: {x+1, (x+1)*x} 无符号歧义场景仍正确");
+    }
+    {
+        std::vector<polynomial_<ZZ>> polys = {(x-1)*(x-1), x*(x-1)};
+        auto [basis, idx] = squarefreebasis(polys);
+        show("sanity_repeated_factor", basis);
+        // 期望：basis 包含 (x-1) 和 x 的 squarefree 表示，无 unit
+        // multiplicity 在 idx 中正确（x-1 在 F[0] 出现 2 次）
+        bool mult_ok = false;
+        for (size_t k = 0; k < basis.size(); ++k) {
+            // 找 x-1 对应的 basis 元素，看 idx[k] 是否记录 (0, 2)
+            for (auto& [i, e] : idx[k]) {
+                if (i == 0 && e == 2) mult_ok = true;
+            }
+        }
+        CHECK(basis_no_unit(basis) && basis_all_squarefree(basis) && mult_ok,
+              "sanity_repeated_factor: 重数 2 正确捕获，无 unit");
+    }
+    {
+        std::vector<polynomial_<ZZ>> polys = {polynomial_<ZZ>(x), x+1};
+        auto [basis, _] = squarefreebasis(polys);
+        show("sanity_coprime", basis);
+        CHECK(basis.size() == 2 && basis_no_unit(basis),
+              "sanity_coprime: {x, x+1} 互素输入返回原集合");
+    }
+
+    // ============================================================
+    // Summary
+    // ============================================================
+    std::cout << "\n========================================" << std::endl;
+    std::cout << "Summary: " << passed << "/" << total << " passed" << std::endl;
+    return passed == total ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

修复 issue #14：`squarefreebasis` 在输出 basis 中混入常数 `-1`，且数量随输入规模增长。

- **根因**：`squarefreefactorize` 的 factor 没做首项 sign 归一化，而 `polynomial_GCD` 内部规范化首项为正。同一数学多项式（associates）在两个函数输出之间字面不齐，使 `squarefreebasis` 主循环 `F1 != lst[j]` 字面比较误判为"应拆分" → 拆分时 `lst[j]/F1` 是 unit (±1) 残留进 basis。
- **修复**：在 `squarefreefactorize` 中加 4 行 sign 归一化（`F_ = F/cont(F)` 后若首项为负则 F_ 和 cont 双方取负），factor 永远首项正，与 `polynomial_GCD` 对齐。
- **对齐业界**：与 SymPy `sqf_list` / Maple `sqrfree` / FLINT `fmpz_poly_factor_squarefree` 的 unit-on-cont、factor-canonical 约定完全一致。

详细方案：[`docs/fixes/2026-05-09-squarefreebasis-unit-leak.md`](docs/fixes/2026-05-09-squarefreebasis-unit-leak.md)
开发日志：[`docs/devlog/2026-05-09-squarefreebasis-unit-leak-fix.md`](docs/devlog/2026-05-09-squarefreebasis-unit-leak-fix.md)

## 影响范围

- C++ 代码：仅 `clpoly/polynomial_gcd.hh:109-111` 局部 8 行（4 行修复 + 4 行注释）
- 调用点扫描（实测 7 处 sqf 调用 + 2 处测试断言）：全部对 factor sign 不敏感，无需改任何调用方
- 顺手把 `test_factorize_bugfix` 和 `test_squarefreebasis_bugfix` 加入 `run_all_tests.sh`（历史疏漏：之前 bugfix 测试都没进 runner）

## Before / After

**Before**:
```
squarefreebasis({-x+1, (x-1)*x})         → [-1, x-1, x]              ✗
squarefreebasis(6 polys with sign mix)   → [-1, x-1, x, -1, x-2, -1, x-3]  ✗
```

**After**:
```
squarefreebasis({-x+1, (x-1)*x})         → [x-1, x]                  ✓
squarefreebasis(6 polys with sign mix)   → [x-1, x, x-2, x-3]        ✓
```

## Test plan

- [x] 新增 `test/test_squarefreebasis_bugfix.cc`（10 用例 / 10 PASS）
  - issue #14 复现（3 用例：2/4/6 polys）
  - sqf canonical 形式断言（4 用例：单变量负首项、多变量负首项、x*y 负首项、product invariant）
  - Sanity（3 用例：正向用例不破坏，含重数 2 验证）
- [x] 全量回归 `bash test/run_all_tests.sh`：26 test files 全 PASS
- [x] sqf 输出与 SymPy ground truth 对比一致（含 `-x+1`、`-6(x-1)(x-2)`、`-xy+1` 等）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)